### PR TITLE
Habit event object creation, and minor fix for add habit fragment.

### DIFF
--- a/app/src/main/java/com/example/recurring_o_city/AddHabitFragment.java
+++ b/app/src/main/java/com/example/recurring_o_city/AddHabitFragment.java
@@ -35,6 +35,7 @@ public class AddHabitFragment extends DialogFragment
     private EditText habitTitle;
     private EditText habitReason;
     private EditText habitDate;
+    private EditText habitRepeat;
     private ImageButton button;
     private ImageButton repeat;
     private OnFragmentInteractionListener listener;
@@ -48,6 +49,7 @@ public class AddHabitFragment extends DialogFragment
     @Override
     public void onRepeatSavePressed(List<String> repeat_list) {
         repeat_strg = repeat_list;
+        habitRepeat.setText(String.join(",", repeat_strg));
     }
 
     public interface OnFragmentInteractionListener{
@@ -91,6 +93,7 @@ public class AddHabitFragment extends DialogFragment
         habitDate = view.findViewById(R.id.habit_date);
         button = view.findViewById(R.id.button);
         repeat = view.findViewById(R.id.repeat_button);
+        habitRepeat = view.findViewById(R.id.habit_frequency);
         habitPrivacy = view.findViewById(R.id.privacy);
 
 


### PR DESCRIPTION
- Habit event object creation has been implemented! They exist as a subcollection under the habit document. Please look over the changed ItemAdapter code, because it contains how to access document within that subcollection.
- Some minor fix for add habit fragment; now the repeat text field should update properly once the user has clicked "save" on the repeat fragment.